### PR TITLE
Update API documentation to match updates on nested objects handling

### DIFF
--- a/source/includes/_client_calls.md
+++ b/source/includes/_client_calls.md
@@ -7,13 +7,13 @@ This endpoint returns a paginated list of client calls as well as pagination lin
 > GET /api/client_calls
 
 ```shell
-curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?page=6&per_page=1"
+curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?page=1&per_page=1"
 ```
 
 ```ruby
   credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
 
-  response = Excon.get('https://app.monami.io/api/client_calls?page=6&per_page=1',
+  response = Excon.get('https://app.monami.io/api/client_calls?page=1&per_page=1',
     headers: {
       'Content-Type' :  'application/json',
       'Authorization' :  "Basic #{credential}"
@@ -30,17 +30,17 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
             "id": 11,
             "attempt_count": 0,
             "status": "completed",
-            "completed_call_start_at": "2024-02-27T15:40:55.980Z",
-            "slug": "481a1528509286d5",
-            "created_at": "2024-02-27T15:40:55.994Z",
-            "updated_at": "2024-02-27T15:41:21.358Z",
-            "completed_call_duration_in_minutes": 25.0,
+            "completed_call_start_at": "2024-03-12T14:17:51.196Z",
+            "slug": "43e98a9667ab8be7",
+            "created_at": "2024-03-12T14:17:51.219Z",
+            "updated_at": "2024-03-12T14:18:59.225Z",
+            "completed_call_duration_in_minutes": 10.0,
             "program": {
                 "id": 1,
                 "name": "Community Services",
                 "short_name": null,
-                "created_at": "2024-02-27T15:40:36.959Z",
-                "updated_at": "2024-02-27T15:41:16.780Z",
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
                 "type": "internal",
                 "description": null,
                 "category": null,
@@ -51,14 +51,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                 "id": 13,
                 "name": "III-B",
                 "status": "active",
-                "created_at": "2024-02-27T15:41:16.651Z",
-                "updated_at": "2024-02-27T15:41:16.651Z",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
                 "label": "iii_b"
             },
             "service_definition": {
                 "id": 30,
-                "created_at": "2024-02-27T15:41:16.785Z",
-                "updated_at": "2024-02-27T15:41:16.785Z",
+                "created_at": "2024-03-12T14:18:53.391Z",
+                "updated_at": "2024-03-12T14:18:53.391Z",
                 "default_frequency": "weekly",
                 "name": "Telephone socialization",
                 "short_name": null,
@@ -66,13 +66,15 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                 "status": "active"
             },
             "client": {
-                "id": 2,
+                "id": 3,
                 "status": "active",
-                "created_at": "2024-02-27T07:40:43.088-08:00",
-                "updated_at": "2024-02-27T07:45:05.875-08:00",
+                "created_at": "2024-03-12T07:17:35.597-07:00",
+                "updated_at": "2024-03-12T07:19:00.470-07:00",
                 "external_id": null,
-                "label": "ami-f3e8ee17",
+                "label": "ami-2bff7b48",
                 "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -81,16 +83,17 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                     "zip": "94306"
                 },
                 "person": {
-                    "id": 13,
+                    "id": 16,
                     "first_name": "My String",
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1934-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:42.601Z",
-                    "updated_at": "2024-02-27T15:45:05.848Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1943-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:34.924Z",
+                    "updated_at": "2024-03-12T14:19:00.465Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075511226",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -100,15 +103,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
             "volunteer": {
                 "id": 1,
                 "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
                 "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "sample@monami.io",
-                "label": "danielle-r-nihil-a-et",
+                "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -122,11 +122,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -136,15 +137,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
         }
     ],
     "links": {
-        "self": "http://app.monami.test/api/client_calls?page=6&per_page=1",
+        "self": "http://app.monami.test/api/client_calls?page=1&per_page=1",
         "first": "http://app.monami.test/api/client_calls?page=1&per_page=1",
-        "prev": "http://app.monami.test/api/client_calls?page=5&per_page=1",
-        "next": "http://app.monami.test/api/client_calls?page=7&per_page=1",
+        "next": "http://app.monami.test/api/client_calls?page=2&per_page=1",
         "last": "http://app.monami.test/api/client_calls?page=23&per_page=1"
     },
     "meta": {
         "total_pages": 23,
-        "current_page": 6
+        "current_page": 1
     }
 }
 ```
@@ -191,113 +191,114 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls/11
 
 ```json
 {
-            "id": 11,
-            "attempt_count": 0,
-            "status": "completed",
-            "completed_call_start_at": "2024-02-27T15:40:55.980Z",
-            "slug": "481a1528509286d5",
-            "created_at": "2024-02-27T15:40:55.994Z",
-            "updated_at": "2024-02-27T15:41:21.358Z",
-            "completed_call_duration_in_minutes": 25.0,
-            "program": {
-                "id": 1,
-                "name": "Community Services",
-                "short_name": null,
-                "created_at": "2024-02-27T15:40:36.959Z",
-                "updated_at": "2024-02-27T15:41:16.780Z",
-                "type": "internal",
-                "description": null,
-                "category": null,
-                "reporting_framework": "oaa",
-                "label": "community_services"
-            },
-            "funding_source": {
-                "id": 13,
-                "name": "III-B",
-                "status": "active",
-                "created_at": "2024-02-27T15:41:16.651Z",
-                "updated_at": "2024-02-27T15:41:16.651Z",
-                "label": "iii_b"
-            },
-            "service_definition": {
-                "id": 30,
-                "created_at": "2024-02-27T15:41:16.785Z",
-                "updated_at": "2024-02-27T15:41:16.785Z",
-                "default_frequency": "weekly",
-                "name": "Telephone socialization",
-                "short_name": null,
-                "label": "telephone_socialization",
-                "status": "active"
-            },
-            "client": {
-                "id": 2,
-                "status": "active",
-                "created_at": "2024-02-27T07:40:43.088-08:00",
-                "updated_at": "2024-02-27T07:45:05.875-08:00",
-                "external_id": null,
-                "label": "ami-f3e8ee17",
-                "custom_fields": {},
-                "address": {
-                    "address_line1": "My String",
-                    "address_line2": null,
-                    "city": "Palo Alto",
-                    "state": "CA",
-                    "zip": "94306"
-                },
-                "person": {
-                    "id": 13,
-                    "first_name": "My String",
-                    "preferred_name": "My String",
-                    "middle_name": null,
-                    "last_name": "My String",
-                    "date_of_birth": "1934-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:42.601Z",
-                    "updated_at": "2024-02-27T15:45:05.848Z",
-                    "gender": "Prefer not to say",
-                    "primary_language": "english",
-                    "languages": [
-                        "spanish"
-                    ]
-                }
-            },
-            "volunteer": {
-                "id": 1,
-                "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
-                "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "sample@monami.io",
-                "label": "danielle-r-nihil-a-et",
-                "custom_fields": {},
-                "address": {
-                    "address_line1": "My String",
-                    "address_line2": null,
-                    "city": "Palo Alto",
-                    "state": "CA",
-                    "zip": "94306"
-                },
-                "person": {
-                    "id": 7,
-                    "first_name": "My String",
-                    "preferred_name": "My String",
-                    "middle_name": null,
-                    "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
-                    "primary_language": "english",
-                    "languages": [
-                        "spanish"
-                    ]
-                }
-            }
+    "id": 11,
+    "attempt_count": 0,
+    "status": "completed",
+    "completed_call_start_at": "2024-03-12T14:17:51.196Z",
+    "slug": "43e98a9667ab8be7",
+    "created_at": "2024-03-12T14:17:51.219Z",
+    "updated_at": "2024-03-12T14:18:59.225Z",
+    "completed_call_duration_in_minutes": 10.0,
+    "program": {
+        "id": 1,
+        "name": "Community Services",
+        "short_name": null,
+        "created_at": "2024-03-12T14:17:24.975Z",
+        "updated_at": "2024-03-12T14:18:53.381Z",
+        "type": "internal",
+        "description": null,
+        "category": null,
+        "reporting_framework": "oaa",
+        "label": "community_services"
+    },
+    "funding_source": {
+        "id": 13,
+        "name": "III-B",
+        "status": "active",
+        "created_at": "2024-03-12T14:18:53.053Z",
+        "updated_at": "2024-03-12T14:18:53.053Z",
+        "label": "iii_b"
+    },
+    "service_definition": {
+        "id": 30,
+        "created_at": "2024-03-12T14:18:53.391Z",
+        "updated_at": "2024-03-12T14:18:53.391Z",
+        "default_frequency": "weekly",
+        "name": "Telephone socialization",
+        "short_name": null,
+        "label": "telephone_socialization",
+        "status": "active"
+    },
+    "client": {
+        "id": 3,
+        "status": "active",
+        "created_at": "2024-03-12T07:17:35.597-07:00",
+        "updated_at": "2024-03-12T07:19:00.470-07:00",
+        "external_id": null,
+        "label": "ami-2bff7b48",
+        "custom_fields": {},
+        "primary_language": null,
+        "languages": null,
+        "address": {
+            "address_line1": "My String",
+            "address_line2": null,
+            "city": "Palo Alto",
+            "state": "CA",
+            "zip": "94306"
+        },
+        "person": {
+            "id": 16,
+            "first_name": "My String",
+            "preferred_name": "My String",
+            "middle_name": null,
+            "last_name": "My String",
+            "date_of_birth": "1943-03-12",
+            "email": "email@monami.io",
+            "created_at": "2024-03-12T14:17:34.924Z",
+            "updated_at": "2024-03-12T14:19:00.465Z",
+            "gender": "prefer_not_to_say",
+            "primary_phone_number": "+17075511226",
+            "primary_language": "english",
+            "languages": [
+                "spanish"
+            ]
         }
+    },
+    "volunteer": {
+        "id": 1,
+        "status": "approved",
+        "created_at": "2024-03-12T07:17:28.069-07:00",
+        "updated_at": "2024-03-12T07:17:29.032-07:00",
+        "external_id": null,
+        "label": "twyla-r-earum-rerum-eum",
+        "custom_fields": {},
+        "languages": null,
+        "address": {
+            "address_line1": "My String",
+            "address_line2": null,
+            "city": "Palo Alto",
+            "state": "CA",
+            "zip": "94306"
+        },
+        "person": {
+            "id": 7,
+            "first_name": "My String",
+            "preferred_name": "My String",
+            "middle_name": null,
+            "last_name": "My String",
+            "date_of_birth": "1930-03-12",
+            "email": "email@monami.io",
+            "created_at": "2024-03-12T14:17:27.096Z",
+            "updated_at": "2024-03-12T14:17:29.037Z",
+            "gender": "prefer_not_to_say",
+            "primary_phone_number": "+17075514082",
+            "primary_language": "english",
+            "languages": [
+                "spanish"
+            ]
+        }
+    }
+}
 ```
 
 This endpoint retrieves a specific client call.
@@ -336,43 +337,73 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
 {
     "client_calls": [
         {
-            "id": 4,
+            "id": 11,
             "attempt_count": 0,
             "status": "completed",
-            "completed_call_start_at": "2024-02-27T15:40:54.928Z",
-            "slug": "7939893dfb5eec24",
-            "created_at": "2024-02-27T15:40:54.936Z",
-            "updated_at": "2024-02-27T15:41:21.310Z",
-            "completed_call_duration_in_minutes": 29.0,
-            "program": null,
-            "funding_source": null,
-            "service_definition": null,
-            "client": {
-                "id": 6,
+            "completed_call_start_at": "2024-03-12T14:17:51.196Z",
+            "slug": "43e98a9667ab8be7",
+            "created_at": "2024-03-12T14:17:51.219Z",
+            "updated_at": "2024-03-12T14:18:59.225Z",
+            "completed_call_duration_in_minutes": 10.0,
+            "program": {
+                "id": 1,
+                "name": "Community Services",
+                "short_name": null,
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
+                "type": "internal",
+                "description": null,
+                "category": null,
+                "reporting_framework": "oaa",
+                "label": "community_services"
+            },
+            "funding_source": {
+                "id": 13,
+                "name": "III-B",
                 "status": "active",
-                "created_at": "2024-02-27T07:40:48.408-08:00",
-                "updated_at": "2024-02-27T07:45:05.995-08:00",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
+                "label": "iii_b"
+            },
+            "service_definition": {
+                "id": 30,
+                "created_at": "2024-03-12T14:18:53.391Z",
+                "updated_at": "2024-03-12T14:18:53.391Z",
+                "default_frequency": "weekly",
+                "name": "Telephone socialization",
+                "short_name": null,
+                "label": "telephone_socialization",
+                "status": "active"
+            },
+            "client": {
+                "id": 3,
+                "status": "active",
+                "created_at": "2024-03-12T07:17:35.597-07:00",
+                "updated_at": "2024-03-12T07:19:00.470-07:00",
                 "external_id": null,
-                "label": "ami-c8e79ee7",
+                "label": "ami-2bff7b48",
                 "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
-                    "city": "My String",
-                    "state": "My String",
-                    "zip": "My String"
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
                 },
                 "person": {
-                    "id": 25,
+                    "id": 16,
                     "first_name": "My String",
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "client@monami.io",
-                    "created_at": "2024-02-27T15:40:47.904Z",
-                    "updated_at": "2024-02-27T15:45:05.983Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1943-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:34.924Z",
+                    "updated_at": "2024-03-12T14:19:00.465Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075511226",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -382,21 +413,18 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
             "volunteer": {
                 "id": 1,
                 "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
                 "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "volunteer@monami.io",
-                "label": "My String",
+                "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
-                    "city": "My String",
-                    "state": "My String",
-                    "zip": "My String"
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
                 },
                 "person": {
                     "id": 7,
@@ -404,11 +432,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "volunteer@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -465,20 +494,20 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
 {
     "client_calls": [
         {
-            "id": 14,
+            "id": 6,
             "attempt_count": 0,
             "status": "completed",
-            "completed_call_start_at": "2024-02-27T15:40:56.271Z",
-            "slug": "739d4fec31ddb231",
-            "created_at": "2024-02-27T15:40:56.289Z",
-            "updated_at": "2024-02-27T15:41:21.373Z",
-            "completed_call_duration_in_minutes": 8.0,
+            "completed_call_start_at": "2024-03-12T14:17:50.280Z",
+            "slug": "a11523f3174c8718",
+            "created_at": "2024-03-12T14:17:50.299Z",
+            "updated_at": "2024-03-12T14:18:59.185Z",
+            "completed_call_duration_in_minutes": 7.0,
             "program": {
                 "id": 1,
                 "name": "Community Services",
                 "short_name": null,
-                "created_at": "2024-02-27T15:40:36.959Z",
-                "updated_at": "2024-02-27T15:41:16.780Z",
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
                 "type": "internal",
                 "description": null,
                 "category": null,
@@ -489,14 +518,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "id": 13,
                 "name": "III-B",
                 "status": "active",
-                "created_at": "2024-02-27T15:41:16.651Z",
-                "updated_at": "2024-02-27T15:41:16.651Z",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
                 "label": "iii_b"
             },
             "service_definition": {
                 "id": 30,
-                "created_at": "2024-02-27T15:41:16.785Z",
-                "updated_at": "2024-02-27T15:41:16.785Z",
+                "created_at": "2024-03-12T14:18:53.391Z",
+                "updated_at": "2024-03-12T14:18:53.391Z",
                 "default_frequency": "weekly",
                 "name": "Telephone socialization",
                 "short_name": null,
@@ -504,31 +533,34 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "status": "active"
             },
             "client": {
-                "id": 4,
+                "id": 1,
                 "status": "active",
-                "created_at": "2024-02-27T07:40:46.042-08:00",
-                "updated_at": "2024-02-27T07:45:05.912-08:00",
+                "created_at": "2024-03-12T07:17:30.034-07:00",
+                "updated_at": "2024-03-12T07:19:00.671-07:00",
                 "external_id": null,
-                "label": "ami-06701072",
+                "label": "ami-5b3d9f58",
                 "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
-                    "city": "My String",
-                    "state": "My String",
-                    "zip": "My String"
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
                 },
                 "person": {
-                    "id": 19,
+                    "id": 9,
                     "first_name": "My String",
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1945-02-27",
-                    "email": "client@monami.io",
-                    "created_at": "2024-02-27T15:40:45.482Z",
-                    "updated_at": "2024-02-27T15:45:05.881Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1946-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:29.266Z",
+                    "updated_at": "2024-03-12T14:19:00.668Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514392",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -538,21 +570,18 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
             "volunteer": {
                 "id": 1,
                 "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
                 "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "volunteer@monami.io",
-                "label": "My String",
+                "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
-                    "city": "My String",
-                    "state": "My String",
-                    "zip": "My String"
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
                 },
                 "person": {
                     "id": 7,
@@ -560,11 +589,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "volunteer@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -595,3 +625,161 @@ This endpoint filters based on the volunteer present on a client call.
 | Parameter        | Description                                                                                     |
 | ---------------- | ----------------------------------------------------------------------------------------------- |
 | by_volunteer     | The ID for the volunteer associated with the client call                                        |
+
+## Get Client Calls by Completed Call Start At
+
+> GET /api/client_calls/?q[completed_call_start_at_from]=:date&q[completed_call_start_at_to]=:date
+
+```shell
+curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[completed_call_start_at_from]=2024-03-12&q[completed_call_start_at_to]=2024-03-13&per_page=1
+```
+
+```ruby
+  credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
+
+  Excon.get('https://app.monami.io/api/client_calls?q[completed_call_start_at_from]=2024-03-12&q[completed_call_start_at_to]=2024-03-13&per_page=1',
+    headers: {
+      'Content-Type' :  'application/json',
+      'Authorization' :  "Basic #{credential}"
+    }
+  )
+```
+
+> A sucessful request returns JSON structured like this:
+
+```json
+{
+    "client_calls": [
+        {
+            "id": 11,
+            "attempt_count": 0,
+            "status": "completed",
+            "completed_call_start_at": "2024-03-12T14:17:51.196Z",
+            "slug": "43e98a9667ab8be7",
+            "created_at": "2024-03-12T14:17:51.219Z",
+            "updated_at": "2024-03-12T14:18:59.225Z",
+            "completed_call_duration_in_minutes": 10.0,
+            "program": {
+                "id": 1,
+                "name": "Community Services",
+                "short_name": null,
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
+                "type": "internal",
+                "description": null,
+                "category": null,
+                "reporting_framework": "oaa",
+                "label": "community_services"
+            },
+            "funding_source": {
+                "id": 13,
+                "name": "III-B",
+                "status": "active",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
+                "label": "iii_b"
+            },
+            "service_definition": {
+                "id": 30,
+                "created_at": "2024-03-12T14:18:53.391Z",
+                "updated_at": "2024-03-12T14:18:53.391Z",
+                "default_frequency": "weekly",
+                "name": "Telephone socialization",
+                "short_name": null,
+                "label": "telephone_socialization",
+                "status": "active"
+            },
+            "client": {
+                "id": 3,
+                "status": "active",
+                "created_at": "2024-03-12T07:17:35.597-07:00",
+                "updated_at": "2024-03-12T07:19:00.470-07:00",
+                "external_id": null,
+                "label": "ami-2bff7b48",
+                "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
+                "address": {
+                    "address_line1": "My String",
+                    "address_line2": null,
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
+                },
+                "person": {
+                    "id": 16,
+                    "first_name": "My String",
+                    "preferred_name": "My String",
+                    "middle_name": null,
+                    "last_name": "My String",
+                    "date_of_birth": "1943-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:34.924Z",
+                    "updated_at": "2024-03-12T14:19:00.465Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075511226",
+                    "primary_language": "english",
+                    "languages": [
+                        "spanish"
+                    ]
+                }
+            },
+            "volunteer": {
+                "id": 1,
+                "status": "approved",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
+                "external_id": null,
+                "label": "twyla-r-earum-rerum-eum",
+                "custom_fields": {},
+                "languages": null,
+                "address": {
+                    "address_line1": "My String",
+                    "address_line2": null,
+                    "city": "Palo Alto",
+                    "state": "CA",
+                    "zip": "94306"
+                },
+                "person": {
+                    "id": 7,
+                    "first_name": "My String",
+                    "preferred_name": "My String",
+                    "middle_name": null,
+                    "last_name": "My String",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
+                    "primary_language": "english",
+                    "languages": [
+                        "spanish"
+                    ]
+                }
+            }
+        }
+    ],
+    "links": {
+        "self": "http://app.monami.test/api/client_calls?page=1&per_page=1",
+        "first": "http://app.monami.test/api/client_calls?page=1&per_page=1",
+        "next": "http://app.monami.test/api/client_calls?page=2&per_page=1",
+        "last": "http://app.monami.test/api/client_calls?page=20&per_page=1"
+    },
+    "meta": {
+        "total_pages": 20,
+        "current_page": 1
+    }
+}
+```
+
+This endpoint filters based on the volunteer present on a client call.
+
+<!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
+
+### URL Parameters
+
+| Parameter                    | Description                                                             |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| completed_call_start_at_from | The first date a client call could be completed at in the given range   |
+| completed_call_start_at_to   | The last date a client call could be completed at in the given range    |

--- a/source/includes/_client_calls.md
+++ b/source/includes/_client_calls.md
@@ -73,8 +73,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                 "external_id": null,
                 "label": "ami-2bff7b48",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -108,7 +106,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -237,8 +234,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls/11
         "external_id": null,
         "label": "ami-2bff7b48",
         "custom_fields": {},
-        "primary_language": null,
-        "languages": null,
         "address": {
             "address_line1": "My String",
             "address_line2": null,
@@ -272,7 +267,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls/11
         "external_id": null,
         "label": "twyla-r-earum-rerum-eum",
         "custom_fields": {},
-        "languages": null,
         "address": {
             "address_line1": "My String",
             "address_line2": null,
@@ -383,8 +377,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "external_id": null,
                 "label": "ami-2bff7b48",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -418,7 +410,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -540,8 +531,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "external_id": null,
                 "label": "ami-5b3d9f58",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -575,7 +564,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -697,8 +685,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[c
                 "external_id": null,
                 "label": "ami-2bff7b48",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -732,7 +718,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[c
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,

--- a/source/includes/_clients.md
+++ b/source/includes/_clients.md
@@ -34,8 +34,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/clients?page=1&
       "external_id": null,
       "label": "ami-9776d470",
       "custom_fields": {},
-      "primary_language": null,
-      "languages": null,
       "address": {
         "address_line1": "My String",
         "address_line2": null,
@@ -122,8 +120,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/12
   "external_id": null,
   "label": "ami-9776d470",
   "custom_fields": {},
-  "primary_language": null,
-  "languages": null,
   "address": {
     "address_line1": "My String",
     "address_line2": null,
@@ -165,9 +161,8 @@ This endpoint retrieves a specific client.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/ \
---form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Client\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"test@monami.io\",\"gender\": \"female\",\"primary_phone_number\": \"+17075518391\"}"' \
+--form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Client\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"test@monami.io\",\"gender\": \"female\",\"primary_phone_number\": \"+17075518391\", \"languages\": \"english,portuguese\"}"' \
 --form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
---form 'languages="english,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -181,7 +176,7 @@ url = URI("http://app.monami.test/api/clients/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['person', '{"first_name": "John","preferred_name": "Client","last_name": "Doe","date_of_birth": "1940-05-30","test": "test@monami.io","gender": "female","primary_phone_number": "+17075518391"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['person', '{"first_name": "John","preferred_name": "Client","last_name": "Doe","date_of_birth": "1940-05-30","test": "test@monami.io","gender": "female","primary_phone_number": "+17075518391", "languages": "english,portuguese"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -201,11 +196,6 @@ puts response.read_body
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
-  "primary_language": null,
-  "languages": [
-    "english",
-    "portuguese"
-  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -244,7 +234,6 @@ This endpoint retrieves the newly created client.
 | -------------- | -------------------------------- |
 | person         | JSON formatted person parameters |
 | address        | JSON formatted address parameters|
-| languages      | Comma separated list of Language Object type labels |
 | custom_fields  | JSON formatted custom fields |
 
 #### Person Parameters
@@ -257,6 +246,7 @@ This endpoint retrieves the newly created client.
 | date_of_birth  | Client's date eg.: `YYYY-MM-DD`  |
 | email          | Client's email address           |
 | gender         | Client's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
+| languages      | Comma separated list of Language Object type labels |
 
 #### Address Parameters
 | Parameter      | Description                                   |
@@ -272,7 +262,6 @@ This endpoint retrieves the newly created client.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/82/clients/ \
---form 'languages="spanish,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -286,7 +275,7 @@ url = URI("http://app.monami.test/api/people/82/clients/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['languages', 'spanish,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -306,11 +295,6 @@ puts response.read_body
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
-  "primary_language": null,
-  "languages": [
-    "spanish",
-    "portuguese"
-  ],
   "person": {
     "id": 78,
     "first_name": "Jane",
@@ -326,8 +310,7 @@ puts response.read_body
     "primary_language": null,
     "languages": [
       "english",
-      "portuguese",
-      "spanish"
+      "portuguese"
     ]
   }
 }
@@ -343,6 +326,5 @@ This endpoint creates a client for a specific person.
 | -------------- | -------------------------------- |
 | person_id      | Integer ID present in the URL    |
 | address        | JSON formatted address parameters|
-| languages      | Comma separated list of Language Object type labels |
 | custom_fields  | JSON formatted custom fields |
 

--- a/source/includes/_clients.md
+++ b/source/includes/_clients.md
@@ -27,35 +27,36 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/clients?page=1&
 {
   "clients": [
     {
-      "id": 2,
-      "status": "active",
-      "created_at": "2024-02-27T07:40:43.088-08:00",
-      "updated_at": "2024-02-27T07:45:05.875-08:00",
+      "id": 12,
+      "status": "pending",
+      "created_at": "2024-03-12T07:19:02.114-07:00",
+      "updated_at": "2024-03-12T07:19:02.122-07:00",
       "external_id": null,
-      "label": "ami-f3e8ee17",
+      "label": "ami-9776d470",
       "custom_fields": {},
+      "primary_language": null,
+      "languages": null,
       "address": {
         "address_line1": "My String",
         "address_line2": null,
-        "city": "My String",
-        "state": "My String",
-        "zip": "My String"
+        "city": "San Mateo",
+        "state": "CA",
+        "zip": "94402"
       },
       "person": {
-        "id": 13,
+        "id": 54,
         "first_name": "My String",
-        "preferred_name": "My String",
+        "preferred_name": null,
         "middle_name": null,
         "last_name": "My String",
-        "date_of_birth": "1934-02-27",
-        "email": "client@monami.io",
-        "created_at": "2024-02-27T15:40:42.601Z",
-        "updated_at": "2024-02-27T15:45:05.848Z",
-        "gender": "Prefer not to say",
+        "date_of_birth": "1959-03-12",
+        "email": "email@monami.io",
+        "created_at": "2024-03-12T14:19:02.091Z",
+        "updated_at": "2024-03-12T14:19:02.115Z",
+        "gender": "prefer_not_to_say",
+        "primary_phone_number": "+15044791643",
         "primary_language": "english",
-        "languages": [
-          "spanish"
-        ]
+        "languages": null
       }
     }
   ],
@@ -63,10 +64,10 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/clients?page=1&
     "self": "http://app.monami.test/api/clients?page=1&per_page=1",
     "first": "http://app.monami.test/api/clients?page=1&per_page=1",
     "next": "http://app.monami.test/api/clients?page=2&per_page=1",
-    "last": "http://app.monami.test/api/clients?page=24&per_page=1"
+    "last": "http://app.monami.test/api/clients?page=21&per_page=1"
   },
   "meta": {
-    "total_pages": 24,
+    "total_pages": 21,
     "current_page": 1
   }
 }
@@ -96,13 +97,13 @@ Remember — the info!
 > GET /api/clients/:id
 
 ```shell
-curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/2
+curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/12
 ```
 
 ```ruby
   credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
 
-  Excon.get('https://app.monami.io/api/clients/2',
+  Excon.get('https://app.monami.io/api/clients/12',
     headers: {
       'Content-Type' => 'application/json',
       'Authorization' => "Basic #{credential}"
@@ -114,35 +115,36 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/2
 
 ```json
 {
-  "id": 2,
-  "status": "active",
-  "created_at": "2024-02-27T07:40:43.088-08:00",
-  "updated_at": "2024-02-27T07:45:05.875-08:00",
+  "id": 12,
+  "status": "pending",
+  "created_at": "2024-03-12T07:19:02.114-07:00",
+  "updated_at": "2024-03-12T07:19:02.122-07:00",
   "external_id": null,
-  "label": "ami-f3e8ee17",
+  "label": "ami-9776d470",
   "custom_fields": {},
+  "primary_language": null,
+  "languages": null,
   "address": {
     "address_line1": "My String",
     "address_line2": null,
-    "city": "My String",
-    "state": "My String",
-    "zip": "My String"
+    "city": "San Mateo",
+    "state": "CA",
+    "zip": "94402"
   },
   "person": {
-    "id": 13,
+    "id": 54,
     "first_name": "My String",
-    "preferred_name": "My String",
+    "preferred_name": null,
     "middle_name": null,
     "last_name": "My String",
-    "date_of_birth": "1934-02-27",
-    "email": "client@monami.io",
-    "created_at": "2024-02-27T15:40:42.601Z",
-    "updated_at": "2024-02-27T15:45:05.848Z",
-    "gender": "Prefer not to say",
+    "date_of_birth": "1959-03-12",
+    "email": "email@monami.io",
+    "created_at": "2024-03-12T14:19:02.091Z",
+    "updated_at": "2024-03-12T14:19:02.115Z",
+    "gender": "prefer_not_to_say",
+    "primary_phone_number": "+15044791643",
     "primary_language": "english",
-    "languages": [
-      "spanish"
-    ]
+    "languages": null
   }
 }
 ```
@@ -163,18 +165,9 @@ This endpoint retrieves a specific client.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/ \
---form 'first_name="Jane"' \
---form 'preferred_name="Client"' \
---form 'last_name="Doe"' \
---form 'date_of_birth="1940-05-30"' \
---form 'email="sample@monami.io"' \
---form 'gender="female"' \
---form 'phone="+17075518391"' \
+--form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Client\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"test@monami.io\",\"gender\": \"female\",\"primary_phone_number\": \"+17075518391\"}"' \
+--form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
 --form 'languages="english,portuguese"' \
---form 'address_line1="X Random St"' \
---form 'city="San Francisco"' \
---form 'state="CA"' \
---form 'zip="94117"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -188,7 +181,7 @@ url = URI("http://app.monami.test/api/clients/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['first_name', 'Jane'],['preferred_name', 'Client'],['last_name', 'Doe'],['date_of_birth', '1940-05-30'],['email', 'sample@monami.io'],['gender', 'female'],['phone', '+17075518391'],['languages', 'english,portuguese'],['address_line1', 'X Random St'],['city', 'San Francisco'],['state', 'CA'],['zip', '94117'],['country', 'United States'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['person', '{"first_name": "John","preferred_name": "Client","last_name": "Doe","date_of_birth": "1940-05-30","test": "test@monami.io","gender": "female","primary_phone_number": "+17075518391"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -198,16 +191,21 @@ puts response.read_body
 
 ```json
 {
-  "id": 26,
+  "id": 22,
   "status": "active",
-  "created_at": "2024-02-27T09:51:33.078-08:00",
-  "updated_at": "2024-02-27T09:51:33.078-08:00",
+  "created_at": "2024-03-13T09:04:33.346-07:00",
+  "updated_at": "2024-03-13T09:04:33.346-07:00",
   "external_id": null,
-  "label": "ami-318cbbd8",
+  "label": "ami-c090e55c",
   "custom_fields": {
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
+  "primary_language": null,
+  "languages": [
+    "english",
+    "portuguese"
+  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -216,18 +214,22 @@ puts response.read_body
     "zip": "94117"
   },
   "person": {
-    "id": 82,
+    "id": 78,
     "first_name": "Jane",
     "preferred_name": "Client",
     "middle_name": null,
     "last_name": "Doe",
     "date_of_birth": "1940-05-30",
-    "email": "sample@monami.io",
-    "created_at": "2024-02-27T17:51:32.984Z",
-    "updated_at": "2024-02-27T17:51:33.122Z",
-    "gender": "Female",
+    "email": "test@monami.io",
+    "created_at": "2024-03-13T16:04:33.256Z",
+    "updated_at": "2024-03-13T16:04:33.399Z",
+    "gender": "female",
+    "primary_phone_number": "+17075518391",
     "primary_language": null,
-    "languages": null
+    "languages": [
+      "english",
+      "portuguese"
+    ]
   }
 }
 ```
@@ -240,18 +242,29 @@ This endpoint retrieves the newly created client.
 
 | Parameter      | Description                      |
 | -------------- | -------------------------------- |
-| first_name     | Client's first name      |
-| preferred_name | Client's preferred name  |
-| last_name      | Client's last name       |
-| date_of_birth  | Client's date eg.: `YYYY-MM-DD` |
-| email          | Client's email address          |
-| gender         | Client's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
-| address_line1  | Client's address |
-| city           | Client's City |
-| state          | Clients State 2 letter abbreviation eg.: `CA` |
-| zip            | 5 digits zip code |
+| person         | JSON formatted person parameters |
+| address        | JSON formatted address parameters|
 | languages      | Comma separated list of Language Object type labels |
-| custom_fields | JSON formatted custom fields |
+| custom_fields  | JSON formatted custom fields |
+
+#### Person Parameters
+
+| Parameter      | Description                      |
+| -------------- | -------------------------------- |
+| first_name     | Client's first name              |
+| preferred_name | Client's preferred name          |
+| last_name      | Client's last name               |
+| date_of_birth  | Client's date eg.: `YYYY-MM-DD`  |
+| email          | Client's email address           |
+| gender         | Client's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
+
+#### Address Parameters
+| Parameter      | Description                                   |
+| -------------- | --------------------------------------------- |
+| address_line1  | Client's address                              |
+| city           | Client's City                                 |
+| state          | Clients State 2 letter abbreviation eg.: `CA` |
+| zip            | 5 digits zip code                             |
 
 ## Create a Client for a specific Person
 
@@ -259,18 +272,7 @@ This endpoint retrieves the newly created client.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/82/clients/ \
---form 'first_name="Jane"' \
---form 'preferred_name="Client"' \
---form 'last_name="Doe"' \
---form 'date_of_birth="1940-05-30"' \
---form 'email="sample@monami.io"' \
---form 'gender="female"' \
---form 'phone="+17075518391"' \
---form 'languages="english,portuguese"' \
---form 'address_line1="X Random St"' \
---form 'city="San Francisco"' \
---form 'state="CA"' \
---form 'zip="94117"' \
+--form 'languages="spanish,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -284,7 +286,7 @@ url = URI("http://app.monami.test/api/people/82/clients/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['first_name', 'Jane'],['preferred_name', 'Client'],['last_name', 'Doe'],['date_of_birth', '1940-05-30'],['email', 'sample@monami.io'],['gender', 'female'],['phone', '+17075518391'],['languages', 'english,portuguese'],['address_line1', 'X Random St'],['city', 'San Francisco'],['state', 'CA'],['zip', '94117'],['country', 'United States'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['languages', 'spanish,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -294,41 +296,44 @@ puts response.read_body
 
 ```json
 {
-  "id": 26,
+  "id": 22,
   "status": "active",
-  "created_at": "2024-02-27T09:51:33.078-08:00",
-  "updated_at": "2024-02-27T09:51:33.078-08:00",
+  "created_at": "2024-03-13T09:04:33.346-07:00",
+  "updated_at": "2024-03-13T09:04:33.346-07:00",
   "external_id": null,
-  "label": "ami-318cbbd8",
+  "label": "ami-c090e55c",
   "custom_fields": {
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
-  "address": {
-    "address_line1": "X Random St",
-    "address_line2": null,
-    "city": "San Francisco",
-    "state": "CA",
-    "zip": "94117"
-  },
+  "primary_language": null,
+  "languages": [
+    "spanish",
+    "portuguese"
+  ],
   "person": {
-    "id": 82,
+    "id": 78,
     "first_name": "Jane",
     "preferred_name": "Client",
     "middle_name": null,
     "last_name": "Doe",
     "date_of_birth": "1940-05-30",
-    "email": "sample@monami.io",
-    "created_at": "2024-02-27T17:51:32.984Z",
-    "updated_at": "2024-02-27T17:51:33.122Z",
-    "gender": "Female",
+    "email": "test@monami.io",
+    "created_at": "2024-03-13T16:04:33.256Z",
+    "updated_at": "2024-03-13T16:04:33.399Z",
+    "gender": "female",
+    "primary_phone_number": "+17075518391",
     "primary_language": null,
-    "languages": null
+    "languages": [
+      "english",
+      "portuguese",
+      "spanish"
+    ]
   }
 }
 ```
 
-This endpoint retrieves a specific client.
+This endpoint creates a client for a specific person.
 
 <!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
 
@@ -336,17 +341,8 @@ This endpoint retrieves a specific client.
 
 | Parameter      | Description                      |
 | -------------- | -------------------------------- |
-| id             | The id of the client to retrieve |
-| first_name     | Client's first name      |
-| preferred_name | Client's preferred name  |
-| last_name      | Client's last name       |
-| date_of_birth  | Client's date eg.: `YYYY-MM-DD` |
-| email          | Client's email address          |
-| gender         | Client's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
-| address_line1  | Client's address |
-| city           | Client's City |
-| state          | Clients State 2 letter abbreviation eg.: `CA` |
-| zip            | 5 digits zip code |
+| person_id      | Integer ID present in the URL    |
+| address        | JSON formatted address parameters|
 | languages      | Comma separated list of Language Object type labels |
-| custom_fields | JSON formatted custom fields |
+| custom_fields  | JSON formatted custom fields |
 

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -32,7 +32,7 @@ The Mon Ami API uses the following error codes:
 | 405         | Method Not Allowed    | You tried to access a record with an invalid method.                         |
 | 406         | Not Acceptable        | You requested a format that isn't json.                                      |
 | 410         | Gone                  | The record requested has been removed from our servers.                      |
-| 422         | Unprocessable Entity  | The request has invalid parameters. See the error messages in the respoonse. |
+| 422         | Unprocessable Entity  | The request has invalid parameters. See the error messages in the response.  |
 | 429         | Too Many Requests     | You're requesting too many records! Slow down!                               |
 | 500         | Internal Server Error | We had a problem with our server. Try again later.                           |
 | 503         | Service Unavailable   | We're temporarily offline for maintenance. Please try again later.           |

--- a/source/includes/_visits.md
+++ b/source/includes/_visits.md
@@ -27,23 +27,23 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
 {
     "visits": [
         {
-            "id": 148,
-            "status": "confirmed",
+            "id": 126,
+            "status": "completed",
             "visit_type": "service",
             "schedule_type": "fixed",
-            "scheduled_duration": 90,
-            "scheduled_start_at": "2024-03-01T08:15:00.000-08:00",
-            "created_at": "2024-02-27T07:41:06.279-08:00",
-            "updated_at": "2024-02-27T07:45:06.112-08:00",
-            "start_at": "2024-03-01T08:15:00.000-08:00",
-            "completed_at": "2024-03-01T09:45:00.000-08:00",
-            "duration": 90,
+            "scheduled_duration": 210,
+            "scheduled_start_at": "2024-03-10T15:00:00.000-07:00",
+            "created_at": "2024-03-12T07:18:35.882-07:00",
+            "updated_at": "2024-03-12T07:20:35.498-07:00",
+            "start_at": "2024-03-10T15:00:00.000-07:00",
+            "completed_at": "2024-03-10T18:30:00.000-07:00",
+            "duration": 210,
             "program": {
                 "id": 1,
                 "name": "Community Services",
                 "short_name": null,
-                "created_at": "2024-02-27T15:40:36.959Z",
-                "updated_at": "2024-02-27T15:41:16.780Z",
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
                 "type": "internal",
                 "description": null,
                 "category": null,
@@ -54,14 +54,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
                 "id": 13,
                 "name": "III-B",
                 "status": "active",
-                "created_at": "2024-02-27T15:41:16.651Z",
-                "updated_at": "2024-02-27T15:41:16.651Z",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
                 "label": "iii_b"
             },
             "service_definition": {
                 "id": 32,
-                "created_at": "2024-02-27T15:41:16.795Z",
-                "updated_at": "2024-02-27T15:41:16.795Z",
+                "created_at": "2024-03-12T14:18:53.409Z",
+                "updated_at": "2024-03-12T14:18:53.409Z",
                 "default_frequency": "weekly",
                 "name": "Personal Care",
                 "short_name": null,
@@ -69,31 +69,34 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
                 "status": "active"
             },
             "client": {
-                "id": 3,
+                "id": 2,
                 "status": "active",
-                "created_at": "2024-02-27T07:40:44.729-08:00",
-                "updated_at": "2024-02-27T07:45:05.821-08:00",
+                "created_at": "2024-03-12T07:17:34.014-07:00",
+                "updated_at": "2024-03-12T07:19:00.423-07:00",
                 "external_id": null,
-                "label": "ami-5c29dc9f",
+                "label": "ami-3f472c50",
                 "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
                     "city": "Palo Alto",
                     "state": "CA",
-                    "zip": "94304"
+                    "zip": "94301"
                 },
                 "person": {
-                    "id": 16,
+                    "id": 13,
                     "first_name": "My String",
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1924-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:44.145Z",
-                    "updated_at": "2024-02-27T15:45:05.793Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:33.331Z",
+                    "updated_at": "2024-03-12T14:19:00.410Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075511731",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -103,15 +106,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
             "volunteer": {
                 "id": 1,
                 "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
                 "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "sample@monami.io",
-                "label": "danielle-r-nihil-a-et",
+                "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -125,11 +125,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -176,13 +177,13 @@ Remember — the info!
 > GET /api/visits/:id
 
 ```shell
-curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/148
+curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/126
 ```
 
 ```ruby
   credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
 
-  Excon.get('https://app.monami.io/api/visits/148',
+  Excon.get('https://app.monami.io/api/visits/126',
     headers: {
       'Content-Type' :  'application/json',
       'Authorization' :  "Basic #{credential}"
@@ -194,118 +195,118 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/148
 
 ```json
 {
-            "id": 148,
-            "status": "confirmed",
-            "visit_type": "service",
-            "schedule_type": "fixed",
-            "scheduled_duration": 90,
-            "scheduled_start_at": "2024-03-01T08:15:00.000-08:00",
-            "created_at": "2024-02-27T07:41:06.279-08:00",
-            "updated_at": "2024-02-27T07:45:06.112-08:00",
-            "start_at": "2024-03-01T08:15:00.000-08:00",
-            "completed_at": "2024-03-01T09:45:00.000-08:00",
-            "duration": 90,
-            "program": {
-                "id": 1,
-                "name": "Community Services",
-                "short_name": null,
-                "created_at": "2024-02-27T15:40:36.959Z",
-                "updated_at": "2024-02-27T15:41:16.780Z",
-                "type": "internal",
-                "description": null,
-                "category": null,
-                "reporting_framework": "oaa",
-                "label": "community_services"
-            },
-            "funding_source": {
-                "id": 13,
-                "name": "III-B",
-                "status": "active",
-                "created_at": "2024-02-27T15:41:16.651Z",
-                "updated_at": "2024-02-27T15:41:16.651Z",
-                "label": "iii_b"
-            },
-            "service_definition": {
-                "id": 32,
-                "created_at": "2024-02-27T15:41:16.795Z",
-                "updated_at": "2024-02-27T15:41:16.795Z",
-                "default_frequency": "weekly",
-                "name": "Personal Care",
-                "short_name": null,
-                "label": "personal_care_2",
-                "status": "active"
-            },
-            "client": {
-                "id": 3,
-                "status": "active",
-                "created_at": "2024-02-27T07:40:44.729-08:00",
-                "updated_at": "2024-02-27T07:45:05.821-08:00",
-                "external_id": null,
-                "label": "ami-5c29dc9f",
-                "custom_fields": {},
-                "address": {
-                    "address_line1": "My String",
-                    "address_line2": null,
-                    "city": "Palo Alto",
-                    "state": "CA",
-                    "zip": "94304"
-                },
-                "person": {
-                    "id": 16,
-                    "first_name": "My String",
-                    "preferred_name": "My String",
-                    "middle_name": null,
-                    "last_name": "My String",
-                    "date_of_birth": "1924-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:44.145Z",
-                    "updated_at": "2024-02-27T15:45:05.793Z",
-                    "gender": "Prefer not to say",
-                    "primary_language": "english",
-                    "languages": [
-                        "spanish"
-                    ]
-                }
-            },
-            "volunteer": {
-                "id": 1,
-                "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
-                "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "sample@monami.io",
-                "label": "danielle-r-nihil-a-et",
-                "custom_fields": {},
-                "address": {
-                    "address_line1": "My String",
-                    "address_line2": null,
-                    "city": "Palo Alto",
-                    "state": "CA",
-                    "zip": "94306"
-                },
-                "person": {
-                    "id": 7,
-                    "first_name": "My String",
-                    "preferred_name": "My String",
-                    "middle_name": null,
-                    "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
-                    "primary_language": "english",
-                    "languages": [
-                        "spanish"
-                    ]
-                }
-            },
-            "visit_coding": null
+    "id": 126,
+    "status": "completed",
+    "visit_type": "service",
+    "schedule_type": "fixed",
+    "scheduled_duration": 210,
+    "scheduled_start_at": "2024-03-10T15:00:00.000-07:00",
+    "created_at": "2024-03-12T07:18:35.882-07:00",
+    "updated_at": "2024-03-12T07:20:35.498-07:00",
+    "start_at": "2024-03-10T15:00:00.000-07:00",
+    "completed_at": "2024-03-10T18:30:00.000-07:00",
+    "duration": 210,
+    "program": {
+        "id": 1,
+        "name": "Community Services",
+        "short_name": null,
+        "created_at": "2024-03-12T14:17:24.975Z",
+        "updated_at": "2024-03-12T14:18:53.381Z",
+        "type": "internal",
+        "description": null,
+        "category": null,
+        "reporting_framework": "oaa",
+        "label": "community_services"
+    },
+    "funding_source": {
+        "id": 13,
+        "name": "III-B",
+        "status": "active",
+        "created_at": "2024-03-12T14:18:53.053Z",
+        "updated_at": "2024-03-12T14:18:53.053Z",
+        "label": "iii_b"
+    },
+    "service_definition": {
+        "id": 32,
+        "created_at": "2024-03-12T14:18:53.409Z",
+        "updated_at": "2024-03-12T14:18:53.409Z",
+        "default_frequency": "weekly",
+        "name": "Personal Care",
+        "short_name": null,
+        "label": "personal_care_2",
+        "status": "active"
+    },
+    "client": {
+        "id": 2,
+        "status": "active",
+        "created_at": "2024-03-12T07:17:34.014-07:00",
+        "updated_at": "2024-03-12T07:19:00.423-07:00",
+        "external_id": null,
+        "label": "ami-3f472c50",
+        "custom_fields": {},
+        "primary_language": null,
+        "languages": null,
+        "address": {
+            "address_line1": "My String",
+            "address_line2": null,
+            "city": "Palo Alto",
+            "state": "CA",
+            "zip": "94301"
+        },
+        "person": {
+            "id": 13,
+            "first_name": "My String",
+            "preferred_name": "My String",
+            "middle_name": null,
+            "last_name": "My String",
+            "date_of_birth": "1930-03-12",
+            "email": "email@monami.io",
+            "created_at": "2024-03-12T14:17:33.331Z",
+            "updated_at": "2024-03-12T14:19:00.410Z",
+            "gender": "prefer_not_to_say",
+            "primary_phone_number": "+17075511731",
+            "primary_language": "english",
+            "languages": [
+                "spanish"
+            ]
         }
-
+    },
+    "volunteer": {
+        "id": 1,
+        "status": "approved",
+        "created_at": "2024-03-12T07:17:28.069-07:00",
+        "updated_at": "2024-03-12T07:17:29.032-07:00",
+        "external_id": null,
+        "label": "twyla-r-earum-rerum-eum",
+        "custom_fields": {},
+        "languages": null,
+        "address": {
+            "address_line1": "My String",
+            "address_line2": null,
+            "city": "Palo Alto",
+            "state": "CA",
+            "zip": "94306"
+        },
+        "person": {
+            "id": 7,
+            "first_name": "My String",
+            "preferred_name": "My String",
+            "middle_name": null,
+            "last_name": "My String",
+            "date_of_birth": "1930-03-12",
+            "email": "email@monami.io",
+            "created_at": "2024-03-12T14:17:27.096Z",
+            "updated_at": "2024-03-12T14:17:29.037Z",
+            "gender": "prefer_not_to_say",
+            "primary_phone_number": "+17075514082",
+            "primary_language": "english",
+            "languages": [
+                "spanish"
+            ]
+        }
+    },
+    "visit_coding": null
+}
 ```
 
 This endpoint retrieves a specific visit.
@@ -324,13 +325,13 @@ This endpoint retrieves a specific visit.
 > GET /api/visits/?q[start_at_from]=:start_at_from&q[start_at_to]=:start_at_to
 
 ```shell
-curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_at_from]=8/05/2014&q[start_at_to]=8/05/2023
+curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_at_from]=2024-03-10&q[start_at_to]=2024-03-11&per_page=1
 ```
 
 ```ruby
   credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
 
-  Excon.get('https://app.monami.io/api/visits?q[start_at_from]=2/15/2024&per_page=1',
+  Excon.get('https://app.monami.io/api/visits?q[start_at_from]=2024-03-10&q[start_at_to]=2024-03-11&per_page=1',
     headers: {
       'Content-Type' :  'application/json',
       'Authorization' :  "Basic #{credential}"
@@ -344,23 +345,23 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
 {
     "visits": [
         {
-            "id": 26,
-            "status": "tentative",
+            "id": 6,
+            "status": "completed",
             "visit_type": "service",
             "schedule_type": "fixed",
-            "scheduled_duration": 120,
-            "scheduled_start_at": "2024-02-17T17:15:00.000-08:00",
-            "created_at": "2024-02-13T11:06:07.285-08:00",
-            "updated_at": "2024-02-13T11:09:18.265-08:00",
-            "start_at": "2024-02-17T17:15:00.000-08:00",
-            "completed_at": "2024-02-17T19:15:00.000-08:00",
-            "duration": 120,
+            "scheduled_duration": 210,
+            "scheduled_start_at": "2024-03-10T15:00:00.000-07:00",
+            "created_at": "2024-03-12T07:18:07.987-07:00",
+            "updated_at": "2024-03-12T07:20:34.273-07:00",
+            "start_at": "2024-03-10T15:00:00.000-07:00",
+            "completed_at": "2024-03-10T18:30:00.000-07:00",
+            "duration": 210,
             "program": {
                 "id": 1,
                 "name": "Community Services",
                 "short_name": null,
-                "created_at": "2024-02-13T19:05:55.578Z",
-                "updated_at": "2024-02-13T19:06:38.201Z",
+                "created_at": "2024-03-12T14:17:24.975Z",
+                "updated_at": "2024-03-12T14:18:53.381Z",
                 "type": "internal",
                 "description": null,
                 "category": null,
@@ -371,14 +372,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
                 "id": 13,
                 "name": "III-B",
                 "status": "active",
-                "created_at": "2024-02-13T19:06:38.081Z",
-                "updated_at": "2024-02-13T19:06:38.081Z",
+                "created_at": "2024-03-12T14:18:53.053Z",
+                "updated_at": "2024-03-12T14:18:53.053Z",
                 "label": "iii_b"
             },
             "service_definition": {
                 "id": 32,
-                "created_at": "2024-02-13T19:06:38.213Z",
-                "updated_at": "2024-02-13T19:06:38.213Z",
+                "created_at": "2024-03-12T14:18:53.409Z",
+                "updated_at": "2024-03-12T14:18:53.409Z",
                 "default_frequency": "weekly",
                 "name": "Personal Care",
                 "short_name": null,
@@ -386,31 +387,34 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
                 "status": "active"
             },
             "client": {
-                "id": 3,
+                "id": 1,
                 "status": "active",
-                "created_at": "2024-02-27T07:40:44.729-08:00",
-                "updated_at": "2024-02-27T07:45:05.821-08:00",
+                "created_at": "2024-03-12T07:17:30.034-07:00",
+                "updated_at": "2024-03-12T07:19:00.671-07:00",
                 "external_id": null,
-                "label": "ami-5c29dc9f",
+                "label": "ami-5b3d9f58",
                 "custom_fields": {},
+                "primary_language": null,
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
                     "city": "Palo Alto",
                     "state": "CA",
-                    "zip": "94304"
+                    "zip": "94306"
                 },
                 "person": {
-                    "id": 16,
+                    "id": 9,
                     "first_name": "My String",
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1924-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:44.145Z",
-                    "updated_at": "2024-02-27T15:45:05.793Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1946-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:29.266Z",
+                    "updated_at": "2024-03-12T14:19:00.668Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514392",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -420,15 +424,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
             "volunteer": {
                 "id": 1,
                 "status": "approved",
-                "created_at": "2024-02-27T07:40:39.407-08:00",
-                "updated_at": "2024-02-27T07:40:39.988-08:00",
+                "created_at": "2024-03-12T07:17:28.069-07:00",
+                "updated_at": "2024-03-12T07:17:29.032-07:00",
                 "external_id": null,
-                "first_name": "My String",
-                "preferred_name": "My String",
-                "last_name": "My String",
-                "email": "sample@monami.io",
-                "label": "danielle-r-nihil-a-et",
+                "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
+                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -442,11 +443,12 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
                     "preferred_name": "My String",
                     "middle_name": null,
                     "last_name": "My String",
-                    "date_of_birth": "1946-02-27",
-                    "email": "sample@monami.io",
-                    "created_at": "2024-02-27T15:40:38.788Z",
-                    "updated_at": "2024-02-27T15:40:40.006Z",
-                    "gender": "Prefer not to say",
+                    "date_of_birth": "1930-03-12",
+                    "email": "email@monami.io",
+                    "created_at": "2024-03-12T14:17:27.096Z",
+                    "updated_at": "2024-03-12T14:17:29.037Z",
+                    "gender": "prefer_not_to_say",
+                    "primary_phone_number": "+17075514082",
                     "primary_language": "english",
                     "languages": [
                         "spanish"
@@ -460,10 +462,10 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
         "self": "http://app.monami.test/api/visits?page=1&per_page=1",
         "first": "http://app.monami.test/api/visits?page=1&per_page=1",
         "next": "http://app.monami.test/api/visits?page=2&per_page=1",
-        "last": "http://app.monami.test/api/visits?page=144&per_page=1"
+        "last": "http://app.monami.test/api/visits?page=20&per_page=1"
     },
     "meta": {
-        "total_pages": 144,
+        "total_pages": 20,
         "current_page": 1
     }
 }

--- a/source/includes/_visits.md
+++ b/source/includes/_visits.md
@@ -76,8 +76,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
                 "external_id": null,
                 "label": "ami-3f472c50",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -111,7 +109,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -244,8 +241,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/126
         "external_id": null,
         "label": "ami-3f472c50",
         "custom_fields": {},
-        "primary_language": null,
-        "languages": null,
         "address": {
             "address_line1": "My String",
             "address_line2": null,
@@ -279,7 +274,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/126
         "external_id": null,
         "label": "twyla-r-earum-rerum-eum",
         "custom_fields": {},
-        "languages": null,
         "address": {
             "address_line1": "My String",
             "address_line2": null,
@@ -394,8 +388,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
                 "external_id": null,
                 "label": "ami-5b3d9f58",
                 "custom_fields": {},
-                "primary_language": null,
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,
@@ -429,7 +421,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
                 "external_id": null,
                 "label": "twyla-r-earum-rerum-eum",
                 "custom_fields": {},
-                "languages": null,
                 "address": {
                     "address_line1": "My String",
                     "address_line2": null,

--- a/source/includes/_volunteers.md
+++ b/source/includes/_volunteers.md
@@ -34,7 +34,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/volunteers?page
       "external_id": null,
       "label": "twyla-r-earum-rerum-eum",
       "custom_fields": {},
-      "languages": null,
       "address": {
         "address_line1": "My String",
         "address_line2": null,
@@ -123,7 +122,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/1
   "external_id": null,
   "label": "twyla-r-earum-rerum-eum",
   "custom_fields": {},
-  "languages": null,
   "address": {
     "address_line1": "My String",
     "address_line2": null,
@@ -167,9 +165,8 @@ This endpoint retrieves a specific volunteer.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/ \
---form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Volunteer\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"volunteer@monami.io\",\"gender\": \"male\",\"primary_phone_number\": \"+17075518391\"}"' \
+--form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Volunteer\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"volunteer@monami.io\",\"gender\": \"male\",\"primary_phone_number\": \"+17075518391\", \"languages\": \"english,portuguese\"}"' \
 --form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
---form 'languages="english,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -183,7 +180,7 @@ url = URI("http://app.monami.test/api/volunteers/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['person', '{"first_name": "John","preferred_name": "Volunteer","last_name": "Doe","date_of_birth": "1940-05-30","email": "volunteer@monami.io","gender": "male","primary_phone_number": "+17075518391"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['person', '{"first_name": "John","preferred_name": "Volunteer","last_name": "Doe","date_of_birth": "1940-05-30","email": "volunteer@monami.io","gender": "male","primary_phone_number": "+17075518391", "languages": "english,portuguese"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -203,10 +200,6 @@ puts response.read_body
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
-  "languages": [
-    "english",
-    "portuguese"
-  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -245,7 +238,6 @@ This endpoint retrieves the newly created volunteer.
 | -------------- | -------------------------------- |
 | person         | JSON formatted person parameters |
 | address        | JSON formatted address parameters|
-| languages      | Comma separated list of Language Object type labels |
 | custom_fields  | JSON formatted custom fields |
 
 #### Person Parameters
@@ -258,6 +250,7 @@ This endpoint retrieves the newly created volunteer.
 | date_of_birth  | Volunteer's date eg.: `YYYY-MM-DD`  |
 | email          | Volunteer's email address           |
 | gender         | Volunteer's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
+| languages      | Comma separated list of Language Object type labels |
 
 #### Address Parameters
 | Parameter      | Description                                   |
@@ -274,7 +267,6 @@ This endpoint retrieves the newly created volunteer.
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/79/volunteers/ \
 --form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
---form 'languages="english,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -288,7 +280,7 @@ url = URI("http://app.monami.test/api/people/79/volunteers/")
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -308,10 +300,6 @@ puts response.read_body
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
-  "languages": [
-    "english",
-    "portuguese"
-  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -350,7 +338,6 @@ This endpoint creates a volunteer for a given person.
 | -------------- | -------------------------------- |
 | person_id      | Integer ID present in the URL    |
 | address        | JSON formatted address parameters|
-| languages      | Comma separated list of Language Object type labels |
 | custom_fields  | JSON formatted custom fields |
 
 #### Address Parameters

--- a/source/includes/_volunteers.md
+++ b/source/includes/_volunteers.md
@@ -29,21 +29,18 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/volunteers?page
     {
       "id": 1,
       "status": "approved",
-      "created_at": "2024-02-27T07:40:39.407-08:00",
-      "updated_at": "2024-02-27T07:40:39.988-08:00",
+      "created_at": "2024-03-12T07:17:28.069-07:00",
+      "updated_at": "2024-03-12T07:17:29.032-07:00",
       "external_id": null,
-      "first_name": "My String",
-      "preferred_name": "My String",
-      "last_name": "My String",
-      "email": "sample@monami.io",
-      "label": "My String",
+      "label": "twyla-r-earum-rerum-eum",
       "custom_fields": {},
+      "languages": null,
       "address": {
         "address_line1": "My String",
         "address_line2": null,
-        "city": "My String",
-        "state": "My String",
-        "zip": "My String"
+        "city": "Palo Alto",
+        "state": "CA",
+        "zip": "94306"
       },
       "person": {
         "id": 7,
@@ -51,14 +48,15 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/volunteers?page
         "preferred_name": "My String",
         "middle_name": null,
         "last_name": "My String",
-        "date_of_birth": "1946-02-27",
-        "email": "sample@monami.io",
-        "created_at": "2024-02-27T15:40:38.788Z",
-        "updated_at": "2024-02-27T15:40:40.006Z",
-        "gender": "Prefer not to say",
+        "date_of_birth": "1930-03-12",
+        "email": "email@monami.io",
+        "created_at": "2024-03-12T14:17:27.096Z",
+        "updated_at": "2024-03-12T14:17:29.037Z",
+        "gender": "prefer_not_to_say",
+        "primary_phone_number": "+17075514082",
         "primary_language": "english",
         "languages": [
-            "spanish"
+          "spanish"
         ]
       }
     }
@@ -120,21 +118,18 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/1
 {
   "id": 1,
   "status": "approved",
-  "created_at": "2024-02-27T07:40:39.407-08:00",
-  "updated_at": "2024-02-27T07:40:39.988-08:00",
+  "created_at": "2024-03-12T07:17:28.069-07:00",
+  "updated_at": "2024-03-12T07:17:29.032-07:00",
   "external_id": null,
-  "first_name": "My String",
-  "preferred_name": "My String",
-  "last_name": "My String",
-  "email": "sample@monami.io",
-  "label": "My String",
+  "label": "twyla-r-earum-rerum-eum",
   "custom_fields": {},
+  "languages": null,
   "address": {
     "address_line1": "My String",
     "address_line2": null,
-    "city": "My String",
-    "state": "My String",
-    "zip": "My String"
+    "city": "Palo Alto",
+    "state": "CA",
+    "zip": "94306"
   },
   "person": {
     "id": 7,
@@ -142,14 +137,15 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/1
     "preferred_name": "My String",
     "middle_name": null,
     "last_name": "My String",
-    "date_of_birth": "1946-02-27",
-    "email": "sample@monami.io",
-    "created_at": "2024-02-27T15:40:38.788Z",
-    "updated_at": "2024-02-27T15:40:40.006Z",
-    "gender": "Prefer not to say",
+    "date_of_birth": "1930-03-12",
+    "email": "email@monami.io",
+    "created_at": "2024-03-12T14:17:27.096Z",
+    "updated_at": "2024-03-12T14:17:29.037Z",
+    "gender": "prefer_not_to_say",
+    "primary_phone_number": "+17075514082",
     "primary_language": "english",
     "languages": [
-        "spanish"
+      "spanish"
     ]
   }
 }
@@ -171,18 +167,9 @@ This endpoint retrieves a specific volunteer.
 
 ```shell
 curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/ \
---form 'first_name="Jane"' \
---form 'preferred_name="Volunteer"' \
---form 'last_name="Doe"' \
---form 'date_of_birth="1940-05-30"' \
---form 'email="sample@monami.io"' \
---form 'gender="female"' \
---form 'phone="+17075518391"' \
---form 'languages=" [\"english\", \"portuguese\"]"' \
---form 'address_line1="X Random St"' \
---form 'city="San Francisco"' \
---form 'state="CA"' \
---form 'zip="94117"' \
+--form 'person="{\"first_name\": \"John\",\"preferred_name\": \"Volunteer\",\"last_name\": \"Doe\",\"date_of_birth\": \"1940-05-30\",\"email\": \"volunteer@monami.io\",\"gender\": \"male\",\"primary_phone_number\": \"+17075518391\"}"' \
+--form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
+--form 'languages="english,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -191,12 +178,12 @@ require "uri"
 require "net/http"
 
 credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
-url = URI("http://app.monami.test/api/clients/")
+url = URI("http://app.monami.test/api/volunteers/")
 
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['first_name', 'Jane'],['preferred_name', 'Volunteer'],['last_name', 'Doe'],['date_of_birth', '1940-05-30'],['email', 'sample@monami.io'],['gender', 'female'],['phone', '+17075518391'],['languages', 'english,portuguese'],['address_line1', 'X Random St'],['city', 'San Francisco'],['state', 'CA'],['zip', '94117'],['country', 'United States'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['person', '{"first_name": "John","preferred_name": "Volunteer","last_name": "Doe","date_of_birth": "1940-05-30","email": "volunteer@monami.io","gender": "male","primary_phone_number": "+17075518391"}'],['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -208,18 +195,18 @@ puts response.read_body
 {
   "id": 3,
   "status": "applied",
-  "created_at": "2024-02-27T11:00:43.619-08:00",
-  "updated_at": "2024-02-27T11:00:43.619-08:00",
+  "created_at": "2024-03-13T11:38:00.900-07:00",
+  "updated_at": "2024-03-13T11:38:00.900-07:00",
   "external_id": null,
-  "first_name": "Jane",
-  "preferred_name": "Volunteer",
-  "last_name": "Doe",
-  "email": "sample@monami.io",
   "label": "volunteer-d",
   "custom_fields": {
     "pronouns": "custom_value2",
     "gender_identity": "custom_value"
   },
+  "languages": [
+    "english",
+    "portuguese"
+  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -228,18 +215,22 @@ puts response.read_body
     "zip": "94117"
   },
   "person": {
-    "id": 82,
-    "first_name": "Jane",
+    "id": 79,
+    "first_name": "John",
     "preferred_name": "Volunteer",
     "middle_name": null,
     "last_name": "Doe",
     "date_of_birth": "1940-05-30",
-    "email": "sample@monami.io",
-    "created_at": "2024-02-27T17:51:32.984Z",
-    "updated_at": "2024-02-27T19:00:43.654Z",
-    "gender": "Female",
+    "email": "volunteer@monami.io",
+    "created_at": "2024-03-13T18:38:00.777Z",
+    "updated_at": "2024-03-13T18:38:00.931Z",
+    "gender": "male",
+    "primary_phone_number": "+17075518391",
     "primary_language": null,
-    "languages": null
+    "languages": [
+      "english",
+      "portuguese"
+    ]
   }
 }
 ```
@@ -252,37 +243,38 @@ This endpoint retrieves the newly created volunteer.
 
 | Parameter      | Description                      |
 | -------------- | -------------------------------- |
-| first_name     | Volunteer's first name      |
-| preferred_name | Volunteer's preferred name  |
-| last_name      | Volunteer's last name       |
-| date_of_birth  | Volunteer's date eg.: `YYYY-MM-DD` |
-| email          | Volunteer's email address          |
-| gender         | Volunteer's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
-| address_line1  | Volunteer's address |
-| city           | Volunteer's City |
-| state          | Volunteers State 2 letter abbreviation eg.: `CA` |
-| zip            | 5 digits zip code |
+| person         | JSON formatted person parameters |
+| address        | JSON formatted address parameters|
 | languages      | Comma separated list of Language Object type labels |
-| custom_fields | JSON formatted custom fields |
+| custom_fields  | JSON formatted custom fields |
+
+#### Person Parameters
+
+| Parameter      | Description                      |
+| -------------- | -------------------------------- |
+| first_name     | Volunteer's first name              |
+| preferred_name | Volunteer's preferred name          |
+| last_name      | Volunteer's last name               |
+| date_of_birth  | Volunteer's date eg.: `YYYY-MM-DD`  |
+| email          | Volunteer's email address           |
+| gender         | Volunteer's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
+
+#### Address Parameters
+| Parameter      | Description                                   |
+| -------------- | --------------------------------------------- |
+| address_line1  | Volunteer's address                              |
+| city           | Volunteer's City                                 |
+| state          | Volunteers State 2 letter abbreviation eg.: `CA` |
+| zip            | 5 digits zip code                             |
 
 ## Create a Volunteer for a specific Person
 
 > POST /api/people/:person_id/volunteers/
 
 ```shell
-curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/82/volunteers/ \
---form 'first_name="Jane"' \
---form 'preferred_name="Volunteer"' \
---form 'last_name="Doe"' \
---form 'date_of_birth="1940-05-30"' \
---form 'email="sample@monami.io"' \
---form 'gender="female"' \
---form 'phone="+17075518391"' \
---form 'languages=" [\"english\", \"portuguese\"]"' \
---form 'address_line1="X Random St"' \
---form 'city="San Francisco"' \
---form 'state="CA"' \
---form 'zip="94117"' \
+curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/79/volunteers/ \
+--form 'address="{\"address_line1\": \"X Random St\", \"city\": \"San Francisco\", \"state\": \"CA\", \"zip\": \"94117\"}"' \
+--form 'languages="english,portuguese"' \
 --form 'custom_fields="{\"gender_identity\": \"custom_value\", \"pronouns\": \"custom_value2\"}"'
 ```
 
@@ -291,12 +283,12 @@ require "uri"
 require "net/http"
 
 credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
-url = URI("http://app.monami.test/api/people/82/volunteers/")
+url = URI("http://app.monami.test/api/people/79/volunteers/")
 
 http = Net::HTTP.new(url.host, url.port);
 request = Net::HTTP::Post.new(url)
 request["Authorization"] = "Basic #{credential}"
-form_data = [['first_name', 'Jane'],['preferred_name', 'Volunteer'],['last_name', 'Doe'],['date_of_birth', '1940-05-30'],['email', 'sample@monami.io'],['gender', 'female'],['phone', '+17075518391'],['languages', 'english,portuguese'],['address_line1', 'X Random St'],['city', 'San Francisco'],['state', 'CA'],['zip', '94117'],['country', 'United States'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
+form_data = [['address', '{"address_line1": "X Random St", "city": "San Francisco", "state": "CA", "zip": "94117"}'],['languages', 'english,portuguese'],['custom_fields', '{"gender_identity": "custom_value", "pronouns": "custom_value2"}']]
 request.set_form form_data, 'multipart/form-data'
 response = http.request(request)
 puts response.read_body
@@ -306,20 +298,20 @@ puts response.read_body
 
 ```json
 {
-  "id": 3,
+  "id": 4,
   "status": "applied",
-  "created_at": "2024-02-27T11:00:43.619-08:00",
-  "updated_at": "2024-02-27T11:00:43.619-08:00",
+  "created_at": "2024-03-13T11:42:32.745-07:00",
+  "updated_at": "2024-03-13T11:42:32.745-07:00",
   "external_id": null,
-  "first_name": "Jane",
-  "preferred_name": "Volunteer",
-  "last_name": "Doe",
-  "email": "sample@monami.io",
   "label": "volunteer-d",
   "custom_fields": {
     "pronouns": "custom_value2",
-    "identity": "custom_value"
+    "gender_identity": "custom_value"
   },
+  "languages": [
+    "english",
+    "portuguese"
+  ],
   "address": {
     "address_line1": "X Random St",
     "address_line2": null,
@@ -328,23 +320,27 @@ puts response.read_body
     "zip": "94117"
   },
   "person": {
-    "id": 82,
-    "first_name": "Jane",
+    "id": 79,
+    "first_name": "John",
     "preferred_name": "Volunteer",
     "middle_name": null,
     "last_name": "Doe",
     "date_of_birth": "1940-05-30",
-    "email": "sample@monami.io",
-    "created_at": "2024-02-27T17:51:32.984Z",
-    "updated_at": "2024-02-27T19:00:43.654Z",
-    "gender": "Female",
+    "email": "volunteer@monami.io",
+    "created_at": "2024-03-13T18:38:00.777Z",
+    "updated_at": "2024-03-13T18:42:32.777Z",
+    "gender": "male",
+    "primary_phone_number": "+17075518391",
     "primary_language": null,
-    "languages": null
+    "languages": [
+      "english",
+      "portuguese"
+    ]
   }
 }
 ```
 
-This endpoint retrieves a specific client.
+This endpoint creates a volunteer for a given person.
 
 <!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
 
@@ -352,17 +348,16 @@ This endpoint retrieves a specific client.
 
 | Parameter      | Description                      |
 | -------------- | -------------------------------- |
-| id             | The id of the client to retrieve |
-| first_name     | Client's first name      |
-| preferred_name | Client's preferred name  |
-| last_name      | Client's last name       |
-| date_of_birth  | Client's date eg.: `YYYY-MM-DD` |
-| email          | Client's email address          |
-| gender         | Client's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
-| address_line1  | Client's address |
-| city           | Client's City |
-| state          | Clients State 2 letter abbreviation eg.: `CA` |
-| zip            | 5 digits zip code |
+| person_id      | Integer ID present in the URL    |
+| address        | JSON formatted address parameters|
 | languages      | Comma separated list of Language Object type labels |
-| custom_fields | JSON formatted custom fields |
+| custom_fields  | JSON formatted custom fields |
+
+#### Address Parameters
+| Parameter      | Description                                   |
+| -------------- | --------------------------------------------- |
+| address_line1  | Volunteer's address                              |
+| city           | Volunteer's City                                 |
+| state          | Volunteers State 2 letter abbreviation eg.: `CA` |
+| zip            | 5 digits zip code                             |
 


### PR DESCRIPTION
This PR updates our documentation to match latest changes on how we handle nested objects. 
All `Address` and `Person` attributes are being displayed within the object and not mirrored to the root object (either `Client` or `Volunteer`) as they were. 

Also, for creating a `Client` or `Volunteer` we now accept those attributes as a json formatted data for `person` and `address` fields.

A new filter is now also being documented for the Client Calls endpoint (**Get Client Calls by Completed Call Start At** section).