### PR TITLE
Update add `GET /api/assessments/requests/:id` to _assessments.md

### DIFF
--- a/source/includes/_assessments.md
+++ b/source/includes/_assessments.md
@@ -103,7 +103,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/assessments/req
 ```json
 {
   "id": 2,
-  "source": "api",
   "status": "requested",
   "created_at": "2024-12-10T23:48:51.180Z",
   "updated_at": "2024-12-10T23:48:51.180Z",
@@ -156,7 +155,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/assessments/req
   "requests": [
     {
       "id": 1,
-      "source": "api",
       "status": "completed",
       "created_at": "2024-12-10T23:43:48.318Z",
       "updated_at": "2024-12-10T23:43:52.045Z",

--- a/source/includes/_assessments.md
+++ b/source/includes/_assessments.md
@@ -1,6 +1,6 @@
 # Assessments
 
-## List available templates for assessments
+## List available templates for Assessment Requests
 
 This endpoint returns a collection of Documents Templates that can be used to create Assessment Requests.
 
@@ -172,7 +172,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/assessments/req
         "data": {}
       },
       "links": {
-        "pdf": "http://app.monami.io/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBYlk9IiwiZXhwIjoiMjAyNC0xMi0xMVQwMDoyNDoxNy4yMDNaIiwicHVyIjoiYmxvYl9pZCJ9fQ==--60ce994086da61699e1d05034c0afad08588582a/Screen%20for%20Consumer%20Services%20v1_1733874231"
+        "pdf": "http://app.monami.io/pdf-path"
       }
     }
   ],
@@ -203,3 +203,71 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/assessments/req
 | q[status_eq] | null    | Filter by request status(requested, completed). |
 | page         | 1       | Select the page of results.                     |
 | per_page     | 25      | How many results per page.                      |
+
+## Show an Assessment request
+
+This endpoint returns an assessment request and metadata.
+
+> GET /api/assessments/requests/:id
+
+```shell
+curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/assessments/requests/5"
+```
+
+```ruby
+  credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
+
+  response = Excon.get('https://app.monami.io/api/assessments/requests/5',
+    headers: {
+      'Content-Type' => 'application/json',
+      'Authorization' => "Basic #{credential}"
+    }
+  )
+```
+
+> A sucessful request returns JSON structured like this:
+
+```json
+{
+  "id": 5,
+  "status": "completed",
+  "created_at": "2024-11-14T07:39:01.266Z",
+  "updated_at": "2024-11-14T09:26:06.951Z",
+  "documentable": {
+    "id": 8,
+    "type": "Client",
+    "label": "ami-010101"
+  },
+  "document": {
+    "metadata": {
+      "name": "Screen for Consumer Services v1"
+    },
+    "data": {
+      "adl_dress": "Yes",
+      "iadl_shop": "NO DIFFICULTY",
+      "iadl_summary": "Quis expedita reprehenderit. Fuga consequatur ipsum. Deleniti eum laboriosam.",
+      "iadl_housekeeping": "NO DIFFICULTY",
+      "iadl_manage_money": "NO DIFFICULTY",
+      "meals_last_3_days": "No",
+      "iadl_prepare_meals": "GREAT DIFFICULTY ‑ e.g., little or no involvement in the activity possible",
+      "iadl_use_telephone": "GREAT DIFFICULTY ‑ e.g., little or no involvement in the activity possible",
+      "iadl_transportation": "GREAT DIFFICULTY ‑ e.g., little or no involvement in the activity possible",
+      "assistance_receiving": [],
+      "iadl_manage_medications": "SOME DIFFICULTY ‑ e.g., needs some help, is very slow, or fatigues"
+    }
+  },
+  "links": {
+    "pdf": "https://app.monami.io/pdf-path"
+  }
+}
+```
+
+### Response Parameters
+
+| Parameter    | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| id           | The unique ID of the assessment request.                         |
+| status       | The status of the assessment request. (`requested`, `completed`) |
+| documentable | Type and identification metadata                                 |
+| document     | Document data and metadata                                       |
+| links        | Links to other repreresentaions of the document                  |


### PR DESCRIPTION
- Take out noisy dev urls for PDFs