### PR TITLE
Adds list of currently available webhook topics

### DIFF
--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -98,6 +98,14 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET -d '{ "topic": "client.created", "webhook_
 | topic       | The name of the topic or topics to be notified for. Allows wildcards. Ex `client.*` will receive all client events |
 | webhook_url | The URL you want the webhook notification to POST to.                                                              |
 
+### Available topics
+
+| Model               | Events                        |
+| ------------------- | ----------------------------- |
+| assessments.request | completed, created            |
+| client_call         | completed                     |
+| visit               | completed                     |
+
 ## Delete a webhook subscription
 
 If you're no longer interested in getting webhook notifications, you can destroy a webhook.


### PR DESCRIPTION
Requested: https://github.com/mes-amis/monami/pull/21182#pullrequestreview-2497341605

As this list grows over time, maybe we should replace this section by adding an API endpoint that returns all the available topics, similar to what we currently do for languages?

Also: is there a plan to add client webhooks very soon? If not, would it make more sense for the documentation examples to use a topic that _does_ exist? (e.g. `client.*` -> `assessments.request*`)

<img width="680" alt="Capture d’écran 2024-12-12 à 2 47 57 PM" src="https://github.com/user-attachments/assets/f98dbcff-44ec-46be-884c-a57a5fc7da46" />
