### PR TITLE
Add adopt sections for client, person, volunteer

### DIFF
--- a/source/includes/_client_calls.md
+++ b/source/includes/_client_calls.md
@@ -101,7 +101,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             },
             "volunteer": {
@@ -140,7 +141,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/client_calls?pa
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             }
         }
@@ -274,7 +276,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls/11
                     "primary": true,
                     "label": "cell"
                 }
-            ]
+            ],
+            "sites": []
         }
     },
     "volunteer": {
@@ -313,7 +316,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls/11
                     "primary": true,
                     "label": "cell"
                 }
-            ]
+            ],
+            "sites": []
         }
     }
 }
@@ -429,7 +433,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             },
             "volunteer": {
@@ -468,7 +473,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             }
         }
@@ -595,7 +601,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             },
             "volunteer": {
@@ -634,7 +641,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[b
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             }
         }
@@ -761,7 +769,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[c
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             },
             "volunteer": {
@@ -800,7 +809,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/client_calls?q[c
                             "primary": true,
                             "label": "cell"
                         }
-                    ]
+                    ],
+                    "sites": []
                 }
             }
         }

--- a/source/includes/_clients.md
+++ b/source/includes/_clients.md
@@ -457,6 +457,108 @@ This endpoint returns the updated client.
 | state         | Client's state. 2-letter abbreviation e.g.: `CA` |
 | zip           | 5 digits zip code                                |
 
+## Adopt a Client
+
+> PATCH /api/clients/:client_label/adopt
+
+```shell
+curl -i -u $MONAMI_UID:$MONAMI_SECRET \
+-X PATCH https://app.monami.io/api/clients/ami-c090e55c/adopt \
+-H 'Content-Type: application/json'
+```
+
+```ruby
+credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
+
+response = Excon.put('https://app.monami.io/api/clients/ami-c090e55c/adopt',
+  headers: {
+    'Content-Type' => 'application/json',
+    'Authorization' => "Basic #{credential}"
+  }
+)
+```
+
+> An adoptable client response contains JSON structured like this:
+
+```json
+{
+  "label": "ami-c090e55c",
+  "person": {
+    "id": 78,
+    "first_name": "Jane",
+    "preferred_name": "Client",
+    "middle_name": null,
+    "last_name": "Doe",
+    "email": "new_email@monami.io",
+    "phone_numbers": [
+      {
+        "number": "+17075518391",
+        "primary": true,
+        "label": "home"
+      }
+    ],
+    "sites": []
+  }
+}
+```
+
+> A sucessful adoption request returns JSON structured like this:
+
+```json
+{
+  "id": 22,
+  "status": "active",
+  "created_at": "2024-03-13T09:04:33.346-07:00",
+  "updated_at": "2024-03-13T09:04:33.346-07:00",
+  "external_id": null,
+  "label": "ami-c090e55c",
+  "custom_fields": {
+    "pronouns": "custom_value2",
+    "gender_identity": "custom_value"
+  },
+  "address": {
+    "address_line1": "X Random St",
+    "address_line2": "Apt 2B",
+    "city": "San Francisco",
+    "state": "CA",
+    "zip": "94117"
+  },
+  "person": {
+    "id": 78,
+    "first_name": "Jane",
+    "preferred_name": "Client",
+    "middle_name": null,
+    "last_name": "Doe",
+    "date_of_birth": "1940-05-30",
+    "email": "new_email@monami.io",
+    "created_at": "2024-03-13T16:04:33.256Z",
+    "updated_at": "2024-03-13T16:04:33.399Z",
+    "gender": "female",
+    "phone_numbers": [
+      {
+        "number": "+17075518391",
+        "primary": true,
+        "label": "home"
+      }
+    ],
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
+    "sites": ["my_credential_site"]
+  }
+}
+```
+
+This endpoint adds a specific client to a site credential's site, and returns the full client response.
+
+<!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
+
+### URL Parameters
+
+| Parameter    | Description                         |
+| ------------ | ----------------------------------- |
+| client_label | The label of the client to adopt |
+
+
 ## List Documents for a Client
 
 This endpoint returns a paginated list of Documents that have been completed for a Client.

--- a/source/includes/_clients.md
+++ b/source/includes/_clients.md
@@ -52,6 +52,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/clients?page=1&
         "created_at": "2024-03-12T14:19:02.091Z",
         "updated_at": "2024-03-12T14:19:02.115Z",
         "gender": "prefer_not_to_say",
+        "primary_language": "english",
+        "languages": null,
         "phone_numbers": [
           {
             "number": "+15044791643",
@@ -59,8 +61,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/clients?page=1&
             "label": "home"
           }
         ],
-        "primary_language": "english",
-        "languages": null
+        "sites": []
       }
     }
   ],
@@ -151,6 +152,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/12
     "created_at": "2024-03-12T14:19:02.091Z",
     "updated_at": "2024-03-12T14:19:02.115Z",
     "gender": "prefer_not_to_say",
+    "primary_language": "english",
+    "languages": null,
     "phone_numbers": [
       {
         "number": "+15044791643",
@@ -158,8 +161,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/clients/12
         "label": "home"
       }
     ],
-    "primary_language": "english",
-    "languages": null
+    "sites": []
   }
 }
 ```
@@ -233,6 +235,8 @@ puts response.read_body
     "created_at": "2024-03-13T16:04:33.256Z",
     "updated_at": "2024-03-13T16:04:33.399Z",
     "gender": "female",
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
     "phone_numbers": [
       {
         "number": "+17075518391",
@@ -240,8 +244,7 @@ puts response.read_body
         "label": "home"
       }
     ],
-    "primary_language": null,
-    "languages": ["english", "portuguese"]
+    "sites": []
   }
 }
 ```
@@ -329,6 +332,8 @@ puts response.read_body
     "created_at": "2024-03-13T16:04:33.256Z",
     "updated_at": "2024-03-13T16:04:33.399Z",
     "gender": "female",
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
     "phone_numbers": [
       {
         "number": "+17075518391",
@@ -336,8 +341,7 @@ puts response.read_body
         "label": "home"
       }
     ],
-    "primary_language": null,
-    "languages": ["english", "portuguese"]
+    "sites": []
   }
 }
 ```
@@ -412,6 +416,8 @@ response = Excon.put('https://app.monami.io/api/clients/22',
     "created_at": "2024-03-13T16:04:33.256Z",
     "updated_at": "2024-03-13T16:04:33.399Z",
     "gender": "female",
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
     "phone_numbers": [
       {
         "number": "+17075518391",
@@ -419,8 +425,7 @@ response = Excon.put('https://app.monami.io/api/clients/22',
         "label": "home"
       }
     ],
-    "primary_language": null,
-    "languages": ["english", "portuguese"]
+    "sites": []
   }
 }
 ```
@@ -534,6 +539,8 @@ response = Excon.put('https://app.monami.io/api/clients/ami-c090e55c/adopt',
     "created_at": "2024-03-13T16:04:33.256Z",
     "updated_at": "2024-03-13T16:04:33.399Z",
     "gender": "female",
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
     "phone_numbers": [
       {
         "number": "+17075518391",
@@ -541,8 +548,6 @@ response = Excon.put('https://app.monami.io/api/clients/ami-c090e55c/adopt',
         "label": "home"
       }
     ],
-    "primary_language": null,
-    "languages": ["english", "portuguese"],
     "sites": ["my_credential_site"]
   }
 }

--- a/source/includes/_people.md
+++ b/source/includes/_people.md
@@ -37,6 +37,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/people?page=2&p
             "created_at": "2024-01-25T15:56:29.766Z",
             "updated_at": "2024-01-25T15:56:29.766Z",
             "gender": "Female",
+            "primary_language": "english",
+            "languages": ["spanish"],
             "phone_numbers": [
               {
                 "number": "+15044791643",
@@ -44,8 +46,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/people?page=2&p
                 "label": "home"
               }
             ],
-            "primary_language": "english",
-            "languages": ["spanish"]
+            "sites": []
         }
     ],
     "links": {
@@ -113,6 +114,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/6
     "created_at": "2024-01-25T15:56:29.766Z",
     "updated_at": "2024-02-16T20:33:51.338Z",
     "gender": "Female",
+    "primary_language": "english",
+    "languages": ["spanish"],
     "phone_numbers": [
       {
         "number": "+15044791643",
@@ -120,8 +123,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people/6
         "label": "home"
       },
     ],
-    "primary_language": "english",
-    "languages": ["spanish"]
+    "sites": []
 }
 ```
 
@@ -171,6 +173,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_emai
             "created_at": "2024-01-25T15:56:29.766Z",
             "updated_at": "2024-02-16T20:33:51.338Z",
             "gender": "Female",
+            "primary_language": "english",
+            "languages": ["spanish"],
             "phone_numbers": [
               {
                 "number": "+15044791643",
@@ -178,8 +182,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_emai
                 "label": "home"
               },
             ],
-            "primary_language": "english",
-            "languages": ["spanish"]
+            "sites": []
         }
     ],
     "links": {
@@ -239,6 +242,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_volu
             "created_at": "2024-01-25T15:56:30.555Z",
             "updated_at": "2024-01-25T15:56:30.959Z",
             "gender": "Prefer not to say",
+            "primary_language": "english",
+            "languages": ["german"],
             "phone_numbers": [
               {
                 "number": "+15044791643",
@@ -246,8 +251,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_volu
                 "label": "home"
               },
             ],
-            "primary_language": "english",
-            "languages": ["german"]
+            "sites": []
         }
     ],
     "links": {
@@ -307,6 +311,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_clie
             "created_at": "2024-01-25T15:56:30.555Z",
             "updated_at": "2024-01-25T15:56:30.959Z",
             "gender": "Prefer not to say",
+            "primary_language": "english",
+            "languages": ["german"],
             "phone_numbers": [
               {
                 "number": "+15044791643",
@@ -314,8 +320,7 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/people?q[by_clie
                 "label": "home"
               },
             ],
-            "primary_language": "english",
-            "languages": ["german"]
+            "sites": []
         }
     ],
     "links": {
@@ -380,6 +385,8 @@ response = Excon.put('https://app.monami.io/api/people/6',
     "created_at": "2024-01-25T15:56:29.766Z",
     "updated_at": "2024-02-16T20:33:51.338Z",
     "gender": "Female",
+    "primary_language": "english",
+    "languages": ["spanish", "italian"],
     "phone_numbers": [
       {
         "number": "+15044791643",
@@ -387,8 +394,7 @@ response = Excon.put('https://app.monami.io/api/people/6',
         "label": "home"
       },
     ],
-    "primary_language": "english",
-    "languages": ["spanish", "italian"]
+    "sites": []
 }
 ```
 This endpoint returns the updated person.
@@ -463,6 +469,8 @@ response = Excon.put('https://app.monami.io/api/people/78/adopt',
   "created_at": "2024-03-13T16:04:33.256Z",
   "updated_at": "2024-03-13T16:04:33.399Z",
   "gender": "female",
+  "primary_language": null,
+  "languages": ["english", "portuguese"],
   "phone_numbers": [
     {
       "number": "+17075518391",
@@ -470,8 +478,6 @@ response = Excon.put('https://app.monami.io/api/people/78/adopt',
       "label": "home"
     }
   ],
-  "primary_language": null,
-  "languages": ["english", "portuguese"],
   "sites": ["my_credential_site"]
 }
 ```

--- a/source/includes/_people.md
+++ b/source/includes/_people.md
@@ -406,3 +406,82 @@ This endpoint returns the updated person.
 | email          | Person's email address                                                                                                                                                                                  |
 | gender         | Person's gender. Options are: `female`, `male`, `trans_female`, `trans_male`, `non_binary`, `trans_non_binary`, `gender_queer`, `two_spirit`, `questioning_not_sure`, `not_listed`, `prefer_not_to_say` |
 | languages      | Array of Language Object type labels                                                                                                                                                     |
+
+## Adopt a Person
+
+> PATCH /api/people/:id/adopt
+
+```shell
+curl -i -u $MONAMI_UID:$MONAMI_SECRET \
+-X PATCH https://app.monami.io/api/people/78/adopt \
+-H 'Content-Type: application/json'
+```
+
+```ruby
+credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
+
+response = Excon.put('https://app.monami.io/api/people/78/adopt',
+  headers: {
+    'Content-Type' => 'application/json',
+    'Authorization' => "Basic #{credential}"
+  }
+)
+```
+
+> An adoptable person response contains JSON structured like this:
+
+```json
+{
+  "id": 78,
+  "first_name": "Jane",
+  "preferred_name": "Client",
+  "middle_name": null,
+  "last_name": "Doe",
+  "email": "new_email@monami.io",
+  "phone_numbers": [
+    {
+      "number": "+17075518391",
+      "primary": true,
+      "label": "home"
+    }
+  ],
+  "sites": []
+}
+```
+
+> A sucessful adoption request returns JSON structured like this:
+
+```json
+{
+  "id": 78,
+  "first_name": "Jane",
+  "preferred_name": "Client",
+  "middle_name": null,
+  "last_name": "Doe",
+  "date_of_birth": "1940-05-30",
+  "email": "new_email@monami.io",
+  "created_at": "2024-03-13T16:04:33.256Z",
+  "updated_at": "2024-03-13T16:04:33.399Z",
+  "gender": "female",
+  "phone_numbers": [
+    {
+      "number": "+17075518391",
+      "primary": true,
+      "label": "home"
+    }
+  ],
+  "primary_language": null,
+  "languages": ["english", "portuguese"],
+  "sites": ["my_credential_site"]
+}
+```
+
+This endpoint adds a specific person to a site credential's site, and returns the full person response.
+
+<!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
+
+### URL Parameters
+
+| Parameter    | Description                         |
+| ------------ | ----------------------------------- |
+| id           | The id of the person to adopt       |

--- a/source/includes/_visits.md
+++ b/source/includes/_visits.md
@@ -102,7 +102,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
               "primary": true,
               "label": "cell"
             }
-          ]
+          ],
+          "sites": []
         }
       },
       "volunteer": {
@@ -139,7 +140,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/visits?page=1&p
               "primary": true,
               "label": "cell"
             }
-          ]
+          ],
+          "sites": []
         }
       },
       "visit_coding": null
@@ -275,7 +277,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/126
           "primary": true,
           "label": "cell"
         }
-      ]
+      ],
+      "sites": []
     }
   },
   "volunteer": {
@@ -312,7 +315,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits/126
           "primary": true,
           "label": "cell"
         }
-      ]
+      ],
+      "sites": []
     }
   },
   "visit_coding": null
@@ -429,7 +433,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
               "primary": true,
               "label": "cell"
             }
-          ]
+          ],
+          "sites": []
         }
       },
       "volunteer": {
@@ -466,7 +471,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/visits?q[start_a
               "primary": true,
               "label": "cell"
             }
-          ]
+          ],
+          "sites": []
         }
       },
       "visit_coding": null

--- a/source/includes/_volunteers.md
+++ b/source/includes/_volunteers.md
@@ -494,3 +494,105 @@ This endpoint returns the updated volunteer.
 | city          | Volunteer's city                                    |
 | state         | Volunteer's state. 2 letter abbreviation e.g.: `CA` |
 | zip           | 5 digit zip code                                    |
+
+
+## Adopt a Volunteer
+
+> PATCH /api/volunteers/:volunteer_label/adopt
+
+```shell
+curl -i -u $MONAMI_UID:$MONAMI_SECRET \
+-X PATCH https://app.monami.io/api/volunteers/volunteer-d/adopt \
+-H 'Content-Type: application/json'
+```
+
+```ruby
+credential = Base64.strict_encode64 ENV.values_at('MONAMI_UID', 'MONAMI_SECRET').join(':')
+
+response = Excon.put('https://app.monami.io/api/volunteers/volunteer-d/adopt',
+  headers: {
+    'Content-Type' => 'application/json',
+    'Authorization' => "Basic #{credential}"
+  }
+)
+```
+
+> An adoptable client response contains JSON structured like this:
+
+```json
+{
+  "label": "volunteer-d",
+  "person": {
+    "id": 79,
+    "first_name": "John",
+    "preferred_name": "Volunteer",
+    "middle_name": null,
+    "last_name": "Doe",
+    "email": "new_email@monami.io",
+    "phone_numbers": [
+      {
+        "number": "+17075518391",
+        "primary": true,
+        "label": "home"
+      }
+    ],
+    "sites": []
+  }
+}
+```
+
+> A sucessful adoption request returns JSON structured like this:
+
+```json
+{
+  "id": 3,
+  "status": "applied",
+  "created_at": "2024-03-13T11:38:00.900-07:00",
+  "updated_at": "2024-03-13T11:38:00.900-07:00",
+  "external_id": null,
+  "label": "volunteer-d",
+  "custom_fields": {
+    "pronouns": "custom_value2",
+    "gender_identity": "custom_value"
+  },
+  "address": {
+    "address_line1": "X Random St",
+    "address_line2": "Apt 2B",
+    "city": "San Francisco",
+    "state": "CA",
+    "zip": "94117"
+  },
+  "person": {
+    "id": 79,
+    "first_name": "John",
+    "preferred_name": "Volunteer",
+    "middle_name": null,
+    "last_name": "Doe",
+    "date_of_birth": "1940-05-30",
+    "email": "new_email@monami.io",
+    "created_at": "2024-03-13T18:38:00.777Z",
+    "updated_at": "2024-03-13T18:38:00.931Z",
+    "gender": "male",
+    "primary_language": null,
+    "languages": ["english", "portuguese"],
+    "phone_numbers": [
+      {
+        "number": "+17075518391",
+        "primary": true,
+        "label": "cell"
+      }
+    ],
+    "sites": ["my_credential_site"]
+  }
+}
+```
+
+This endpoint adds a specific volunteer to a site credential's site, and returns the full volunteer response.
+
+<!-- <aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside> -->
+
+### URL Parameters
+
+| Parameter       | Description                            |
+| --------------- | -------------------------------------- |
+| volunteer_label | The label of the volunteer to adopt |

--- a/source/includes/_volunteers.md
+++ b/source/includes/_volunteers.md
@@ -52,13 +52,6 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/volunteers?page
         "created_at": "2024-03-12T14:17:27.096Z",
         "updated_at": "2024-03-12T14:17:29.037Z",
         "gender": "prefer_not_to_say",
-        "phone_numbers": [
-          {
-            "number": "+15044791643",
-            "primary": true,
-            "label": "home"
-          }
-        ],
         "primary_language": "english",
         "languages": ["spanish"],
         "phone_numbers": [
@@ -67,7 +60,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET "https://app.monami.io/api/volunteers?page
             "primary": true,
             "label": "cell"
           }
-        ]
+        ],
+        "sites": []
       }
     }
   ],
@@ -159,7 +153,8 @@ curl -i -u $MONAMI_UID:$MONAMI_SECRET https://app.monami.io/api/volunteers/1
         "primary": true,
         "label": "cell"
       }
-    ]
+    ],
+    "sites": []
   }
 }
 ```
@@ -233,13 +228,6 @@ puts response.read_body
     "created_at": "2024-03-13T18:38:00.777Z",
     "updated_at": "2024-03-13T18:38:00.931Z",
     "gender": "male",
-    "phone_numbers": [
-      {
-        "number": "+17075518391",
-        "primary": true,
-        "label": "home"
-      }
-    ],
     "primary_language": null,
     "languages": ["english", "portuguese"],
     "phone_numbers": [
@@ -248,7 +236,8 @@ puts response.read_body
         "primary": true,
         "label": "cell"
       }
-    ]
+    ],
+    "sites": []
   }
 }
 ```
@@ -344,13 +333,6 @@ puts response.read_body
     "created_at": "2024-03-13T18:38:00.777Z",
     "updated_at": "2024-03-13T18:42:32.777Z",
     "gender": "male",
-    "phone_numbers": [
-      {
-        "number": "+17075518391",
-        "primary": true,
-        "label": "home"
-      }
-    ],
     "primary_language": null,
     "languages": ["english", "portuguese"],
     "phone_numbers": [
@@ -359,7 +341,8 @@ puts response.read_body
         "primary": true,
         "label": "cell"
       }
-    ]
+    ],
+    "sites": []
   }
 }
 ```
@@ -443,13 +426,6 @@ response = Excon.put('https://app.monami.io/api/volunteers/3',
     "created_at": "2024-03-13T18:38:00.777Z",
     "updated_at": "2024-03-13T18:38:00.931Z",
     "gender": "male",
-    "phone_numbers": [
-      {
-        "number": "+17075518391",
-        "primary": true,
-        "label": "home"
-      }
-    ],
     "primary_language": null,
     "languages": ["english", "portuguese"],
     "phone_numbers": [
@@ -458,7 +434,8 @@ response = Excon.put('https://app.monami.io/api/volunteers/3',
         "primary": true,
         "label": "cell"
       }
-    ]
+    ],
+    "sites": []
   }
 }
 ```


### PR DESCRIPTION
API changes: https://github.com/mes-amis/monami/pull/21396

*****
Adds "Adopt a [Client | Person | Volunteer]" sections
- includes example of the limited response object

Adds `"sites"` field to all person responses